### PR TITLE
Fixed InfluxDB Chart.yaml referencing the wrong Influx version

### DIFF
--- a/influxdb/Chart.yaml
+++ b/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 1.6.3
+version: 1.7.4
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:
 - influxdb


### PR DESCRIPTION
Fixing: https://github.com/influxdata/kube-influxdb/issues/9